### PR TITLE
bugfix: set unused operands as 0 in mod_random_inst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: proposals_test.out inst_test.out cost_test.out prog_test.out mh_prog_test.out validator_test.out cfg_test.out inout_test.out smt_prog_test.out
 
-proposals_test.out: inst.cc inst.h proposals.cc proposals_test.cc prog.cc prog.h
-	g++ -std=c++11 inst.cc proposals.cc proposals_test.cc prog.cc -o proposals_test.out
+proposals_test.out: inst.cc inst.h proposals.cc proposals_test.cc prog.cc prog.h utils.cc utils.h
+	g++ -std=c++11 inst.cc proposals.cc proposals_test.cc prog.cc utils.cc -o proposals_test.out
 
 inst_test.out: inst.cc inst.h inst_test.cc
 	g++ -std=c++11 inst.cc inst_test.cc -o inst_test.out

--- a/inst.h
+++ b/inst.h
@@ -5,6 +5,8 @@ using namespace std;
 #define NUM_REGS 4
 #define MAX_CONST 20
 #define MAX_PROG_LEN 7
+// Max number of operands in one instruction
+#define MAX_OP_LEN 3
 
 // Operand types for instructions
 #define OP_UNUSED 0

--- a/proposals.cc
+++ b/proposals.cc
@@ -82,5 +82,8 @@ prog* mod_random_inst(const prog& orig) {
     int new_opvalue = get_new_operand(new_opcode, i, -1);
     sel_inst->_args[i] = new_opvalue;
   }
+  for (int i = num_operands[new_opcode]; i < MAX_OP_LEN; i++) {
+    sel_inst->_args[i] = 0;
+  }
   return synth;
 }

--- a/proposals_test.cc
+++ b/proposals_test.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "proposals.h"
 #include "inst.h"
+#include "utils.h"
 
 int test1(int input) {
   cout << "Test 1" << endl;
@@ -47,6 +48,24 @@ int test2(int input) {
     cout << "Transformed program after " << i << " proposals:" << endl;
     print_program(p[i]->inst_list, N);
   }
+  bool assert_res = true;
+  for (int i = 1; i < 6; i++) {
+    for (int j = 0; j < N; j++) {
+      inst ins = p[i]->inst_list[j];
+      int opcode = ins._opcode;
+      for (int k = num_operands[opcode]; k < MAX_OP_LEN; k++) {
+        bool res = (ins._args[k] == 0);
+        if (! res) {
+          assert_res = false;
+          cout << "unused operands _arg[" << k << "] in ";
+          ins.print();
+          cout << "are not 0, but " << ins._args[k] << endl;
+        }
+      }
+    }
+  }
+  print_test_res(assert_res, "set unused operands as 0");
+
   for (int i = 1; i < 6; i++) {
     prog::clear_prog(p[i]);
   }


### PR DESCRIPTION
@ngsrinivas 
Hi, Srinivas. Could you help me review and merge it?
1. set unused operands as 0 in mod_random_inst
2. add a test